### PR TITLE
Replace markdown format

### DIFF
--- a/wp-readme.php
+++ b/wp-readme.php
@@ -37,6 +37,8 @@ $string = preg_replace_callback( '/^(#+)\s+(.*)/mu', function( $match ) {
 	return "{$sep} {$match[2]} {$sep}";
 }, $string );
 
+// Replace markdown format
+$string = preg_replace( '/```/', '`', $string );
 
 //保存
 if ( ! file_put_contents( './readme.txt', $string ) ) {


### PR DESCRIPTION
On [HameSlack](https://wordpress.org/plugins/hameslack/)'s `readme.txt`, **```** should be just **`**.

<img width="588" alt="_2017_01_24_18_41" src="https://cloud.githubusercontent.com/assets/1886443/22242001/094a87d6-e265-11e6-977d-543ba3b0e89b.png">
https://wordpress.org/plugins/hameslack/